### PR TITLE
Add docs to the list of areas covered

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Do not file issues for Crossplane providers or general Crossplane on this reposi
 * Upbound SaaS (Cloud Spaces)
 * Upbound Marketplace
 * up CLI
+* Upbound documentation


### PR DESCRIPTION
Since our docs repository is private these days, add documentation to the list of areas covered by this repository.
