### PR TITLE
Add needs-triage label workflow

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -1,0 +1,13 @@
+name: Add "needs-triage" label to new or reopened issues
+on:
+  issues:
+    types: [opened, reopened]
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add labels to new issue
+        run: |
+          gh issue edit ${{ github.event.issue.number }} --add-label "needs-triage"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Currently we're manually adding `needs-triage` labels to new issues. Ideally this is automated. This is an attempt at doing that.

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Needs to be merged to see if it works.
